### PR TITLE
Update requirements and lite code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     deepspeed==0.7.5
     pynvml
     lightning-gpt==0.1.0
+    tensorboardX
 
 [options.packages.find]
 exclude =

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -12,6 +12,11 @@ from lai_textpred.callbacks import (
 )
 from tests.helpers import setup_ddp
 
+try:
+    from lightning.lite.utilities.distributed import _all_gather_ddp_if_available
+except ImportError:
+    from lightning.fabric.utilities.distributed import _all_gather_ddp_if_available
+
 
 def test_default_callbacks():
     assert isinstance(default_callbacks()[0], lightning.pytorch.callbacks.EarlyStopping)
@@ -149,9 +154,7 @@ def _custom_monitoring_callback_train_mock(rank, world_size):
     trainer.global_rank = rank
     strategy = mock.MagicMock()
     strategy.root_device = torch.device("cpu")
-    strategy.all_gather = (
-        lightning.lite.utilities.distributed._all_gather_ddp_if_available
-    )
+    strategy.all_gather = _all_gather_ddp_if_available
     trainer.strategy = strategy
 
     logger = mock.MagicMock()


### PR DESCRIPTION
Adds tensorboardX as additional requirement here for TB Logger as with lightning 1.9.0 this requirement becomes optional.
Also falls back to fabric for test imports if they are not available in lite.