### PR TITLE
switch order of tensorboard and works

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,10 +5,44 @@
 
 import lightning as L
 import os, torch
+
+from lightning_app.utilities.exceptions import ExitAppException
 from lightning_gpt import models
-from lit_llms.tensorboard import DriveTensorBoardLogger, MultiNodeLightningTrainerWithTensorboard
+from lit_llms.tensorboard import DriveTensorBoardLogger, TensorBoardWork
 
 from lai_textpred import default_callbacks, gpt_20b, WordDataset, error_if_local
+from typing import Any, List, Mapping, Optional, Type
+
+class MultiNodeLightningTrainerWithTensorboard(L.LightningFlow):
+    def __init__(
+            self,
+            work_cls: Type[L.LightningWork],
+            num_nodes: int,
+            cloud_compute: L.CloudCompute,
+            quit_tb_with_training: bool = True,
+    ):
+        super().__init__()
+        tb_drive = L.app.storage.Drive("lit://tb_drive")
+        self.tensorboard_work = TensorBoardWork(drive=tb_drive)
+        self.multinode = L.app.components.LightningTrainerMultiNode(
+            work_cls,
+            num_nodes=num_nodes,
+            cloud_compute=cloud_compute,
+            tb_drive=tb_drive,
+        )
+        self.quit_tb_with_training = quit_tb_with_training
+
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        if self.quit_tb_with_training and all([w.has_succeeded for w in self.multinode.ws]):
+            self.tensorboard_work.stop()
+            raise ExitAppException
+
+        self.multinode.run(*args, **kwargs)
+        self.tensorboard_work.run()
+
+    def configure_layout(self) -> List[Mapping[str, str]]:
+        return [{"name": "Training Logs", "content": self.tensorboard_work.url}]
+
 
 
 class WordPrediction(L.LightningWork):


### PR DESCRIPTION
This PR swaps the creation order of multi training nodes + tensorboard.

Useful for co-location experiments, as the tensorboard work doesn't determine the zone of multi node training